### PR TITLE
Implement matrix-free version with ghost points

### DIFF
--- a/src/ComputeProlongation_ref.cpp
+++ b/src/ComputeProlongation_ref.cpp
@@ -46,13 +46,13 @@ int ComputeProlongation_ref(const SparseMatrix & Af, Vector & xf) {
   const bool MATRIX_FREE = false;
 
   if(MATRIX_FREE) {
-#ifndef HPCG_NO_OPENMP
-#pragma omp parallel for
-#endif
     local_int_t nxc = Af.geom->nx/2;
     local_int_t nyc = Af.geom->ny/2;
     local_int_t nzc = Af.geom->nz/2;
 
+#ifndef HPCG_NO_OPENMP
+#pragma omp parallel for collapse(3)
+#endif
     for(local_int_t izc=0; izc < nzc; ++izc) {
       for(local_int_t iyc=0; iyc < nyc; ++iyc) {
         for(local_int_t ixc=0; ixc < nxc; ++ixc) {
@@ -61,12 +61,11 @@ int ComputeProlongation_ref(const SparseMatrix & Af, Vector & xf) {
       }
     }
   } else {
+    local_int_t * f2c = Af.mgData->f2cOperator;
+    local_int_t nc = Af.mgData->rc->localLength;
 #ifndef HPCG_NO_OPENMP
 #pragma omp parallel for
 #endif
-// TODO: Somehow note that this loop can be safely vectorized since f2c has no repeated indices
-    local_int_t * f2c = Af.mgData->f2cOperator;
-    local_int_t nc = Af.mgData->rc->localLength;
     for (local_int_t i=0; i<nc; ++i) xfv[f2c[i]] += xcv[i]; // This loop is safe to vectorize
   }
 

--- a/src/ComputeProlongation_ref.cpp
+++ b/src/ComputeProlongation_ref.cpp
@@ -22,7 +22,10 @@
 #include <omp.h>
 #endif
 
+#include "idx.hpp"
+
 #include "ComputeProlongation_ref.hpp"
+#include <iostream>
 
 /*!
   Routine to compute the coarse residual vector.
@@ -42,11 +45,25 @@ int ComputeProlongation_ref(const SparseMatrix & Af, Vector & xf) {
   local_int_t * f2c = Af.mgData->f2cOperator;
   local_int_t nc = Af.mgData->rc->localLength;
 
+  local_int_t ix = 0;
+  local_int_t iy = 0;
+  local_int_t iz = 0;
+  local_int_t nx = Af.geom->nx;
+  local_int_t ny = Af.geom->ny;
+  local_int_t nz = Af.geom->nz;
+  local_int_t nlocal = nx*ny*nz;
+
 #ifndef HPCG_NO_OPENMP
 #pragma omp parallel for
 #endif
 // TODO: Somehow note that this loop can be safely vectorized since f2c has no repeated indices
-  for (local_int_t i=0; i<nc; ++i) xfv[f2c[i]] += xcv[i]; // This loop is safe to vectorize
+for (ix=0; ix < nx; ix +=2){
+    for( iy=0; iy< ny; iy +=2){
+        for( iz=0; iz< nz; iz +=2){
+            xfv[idx(ix,iy,iz,nx,ny,nz)] += xcv[idx(ix/2,iy/2,iz/2,nx/2,ny/2,nz/2)];
+        }
+    }
+}
 
   return 0;
 }

--- a/src/ComputeRestriction_ref.cpp
+++ b/src/ComputeRestriction_ref.cpp
@@ -47,13 +47,13 @@ int ComputeRestriction_ref(const SparseMatrix & A, const Vector & rf) {
   const bool MATRIX_FREE = false;
 
   if(MATRIX_FREE) {
-#ifndef HPCG_NO_OPENMP
-#pragma omp parallel for
-#endif
     local_int_t nxc = A.geom->nx/2;
     local_int_t nyc = A.geom->ny/2;
     local_int_t nzc = A.geom->nz/2;
 
+#ifndef HPCG_NO_OPENMP
+#pragma omp parallel for collapse(3)
+#endif
     for(local_int_t izc=0; izc < nzc; ++izc){
       for(local_int_t iyc=0; iyc < nyc; ++iyc){
         for(local_int_t ixc=0; ixc < nxc; ++ixc){

--- a/src/ComputeRestriction_ref.cpp
+++ b/src/ComputeRestriction_ref.cpp
@@ -22,7 +22,8 @@
 #ifndef HPCG_NO_OPENMP
 #include <omp.h>
 #endif
-
+#include <iostream>
+#include "idx.hpp"
 #include "ComputeRestriction_ref.hpp"
 
 /*!
@@ -44,11 +45,22 @@ int ComputeRestriction_ref(const SparseMatrix & A, const Vector & rf) {
   double * rcv = A.mgData->rc->values;
   local_int_t * f2c = A.mgData->f2cOperator;
   local_int_t nc = A.mgData->rc->localLength;
-
+  local_int_t ix = 0;
+  local_int_t iy = 0;
+  local_int_t iz = 0;
+  local_int_t nx = A.geom->nx;
+  local_int_t ny = A.geom->ny;
+  local_int_t nz = A.geom->nz;
+  local_int_t nlocal = nx*ny*nz;
 #ifndef HPCG_NO_OPENMP
 #pragma omp parallel for
 #endif
-  for (local_int_t i=0; i<nc; ++i) rcv[i] = rfv[f2c[i]] - Axfv[f2c[i]];
-
+for (ix=0; ix < nx; ix +=2){
+    for( iy=0; iy< ny; iy +=2){
+        for( iz=0; iz< nz; iz +=2){
+            rcv[idx(ix/2,iy/2,iz/2,nx/2,ny/2,nz/2)] = rfv[idx(ix,iy,iz,nx,ny,nz)] - Axfv[idx(ix,iy,iz,nx,ny,nz)];
+        }
+    }
+}
   return 0;
 }

--- a/src/ComputeSPMV_ref.cpp
+++ b/src/ComputeSPMV_ref.cpp
@@ -41,6 +41,7 @@ int ComputeSPMV_mf( const SparseMatrix & A, Vector & x, Vector & y) {
   global_int_t nz = A.geom->nz;
   const int ng = 1;
   const local_int_t nrow_ghost = (nx+2*ng)*(ny+2*ng)*(nz+2*ng); // local number of rows *including* ghost points
+  // TODO test performance of unique_ptr to replace this scary new
   double* xg = new double[nrow_ghost]{0.0}; // Copy of x with ghost points
 
   // Copy xv to xg TODO HACK find better way to do this

--- a/src/ComputeSPMV_ref.cpp
+++ b/src/ComputeSPMV_ref.cpp
@@ -29,6 +29,11 @@
 #endif
 #include <cassert>
 
+inline int idx(const int ix, const int iy, const int iz, const int nx, const int ny, const int nz, const int ng=0) {
+  // input index of (0, 0, 0) corresponds to first *interior* point. Ghost points are accessed with (-1, -1, -1).
+  return (iz+ng)*(nx+2*ng)*(ny+2*ng)+(iy+ng)*(nx+2*ng)+(ix+ng);
+}
+
 /*!
   Routine to compute matrix vector product y = Ax where:
   Precondition: First call exchange_externals to get off-processor values of x
@@ -55,18 +60,43 @@ int ComputeSPMV_ref( const SparseMatrix & A, Vector & x, Vector & y) {
   const double * const xv = x.values;
   double * const yv = y.values;
   const local_int_t nrow = A.localNumberOfRows;
+
+  global_int_t nx = A.geom->nx;
+  global_int_t ny = A.geom->ny;
+  global_int_t nz = A.geom->nz;
+  global_int_t ng = 1; // number of ghost points
+  const local_int_t nrow_ghost = (nx+2*ng)*(ny+2*ng)*(nz+2*ng); // local number of rows *including* ghost points
+  double* xg = new double[nrow_ghost]; // Copy of x with ghost points
+
+  // Copy xv to xg
+  for (local_int_t ix=0; ix<nx; ++ix) {
+    for (local_int_t iy=0; iy<ny; ++iy) {
+      for (local_int_t iz=0; iz<nz; ++iz) {
+        xg[idx(ix,iy,iz,nx,ny,nz,ng)] = xv[idx(ix,iy,iz,nx,ny,nz)];
+      }
+    }
+  }
+
 #ifndef HPCG_NO_OPENMP
   #pragma omp parallel for
 #endif
-  for (local_int_t i=0; i< nrow; i++)  {
-    double sum = 0.0;
-    const double * const cur_vals = A.matrixValues[i];
-    const local_int_t * const cur_inds = A.mtxIndL[i];
-    const int cur_nnz = A.nonzerosInRow[i];
-
-    for (int j=0; j< cur_nnz; j++)
-      sum += cur_vals[j]*xv[cur_inds[j]];
-    yv[i] = sum;
+  for (local_int_t ix=0; ix<nx; ++ix) {
+    for (local_int_t iy=0; iy<ny; ++iy) {
+      for (local_int_t iz=0; iz<nz; ++iz) {
+        double sum = 0.0;
+        for(int sx=-1; sx<=1; ++sx) {
+          for(int sy=-1; sy<=1; ++sy) {
+            for(int sz=-1; sz<=1; ++sz) {
+              sum += -1.*xg[idx(ix+sx, iy+sy, iz+sz, nx, ny, nz, ng)];
+            }
+          }
+        }
+        sum -= -1.*xg[idx(ix+0, iy+0, iz+0, nx, ny, nz, ng)];
+        sum += 26.*xg[idx(ix+0, iy+0, iz+0, nx, ny, nz, ng)];
+        yv[idx(ix,iy,iz,nx,ny,nz)] = sum;
+      }
+    }
   }
+
   return 0;
 }

--- a/src/ComputeSPMV_ref.cpp
+++ b/src/ComputeSPMV_ref.cpp
@@ -18,6 +18,7 @@
  HPCG routine
  */
 
+#include "idx.hpp"
 #include "ComputeSPMV_ref.hpp"
 
 #ifndef HPCG_NO_MPI
@@ -28,13 +29,6 @@
 #include <omp.h>
 #endif
 #include <cassert>
-
-// FIXME put me somewhere sensible
-inline int idx(const int ix, const int iy, const int iz, const int nx, const int ny, const int nz, const int ng=0) {
-  // input index of (0, 0, 0) corresponds to first *interior* point. Ghost points are accessed with (-1, -1, -1).
-  //return (iz+ng)*(nx+2*ng)*(ny+2*ng)+(iy+ng)*(nx+2*ng)+(ix+ng);
-  return (ix+ng)*(nz+2*ng)*(ny+2*ng)+(iy+ng)*(nz+2*ng)+(iz+ng);
-}
 
 /*!
   Routine to compute matrix vector product y = Ax where:

--- a/src/ComputeSPMV_ref.cpp
+++ b/src/ComputeSPMV_ref.cpp
@@ -29,6 +29,7 @@
 #endif
 #include <cassert>
 
+// FIXME put me somewhere sensible
 inline int idx(const int ix, const int iy, const int iz, const int nx, const int ny, const int nz, const int ng=0) {
   // input index of (0, 0, 0) corresponds to first *interior* point. Ghost points are accessed with (-1, -1, -1).
   return (iz+ng)*(nx+2*ng)*(ny+2*ng)+(iy+ng)*(nx+2*ng)+(ix+ng);
@@ -68,7 +69,7 @@ int ComputeSPMV_ref( const SparseMatrix & A, Vector & x, Vector & y) {
   const local_int_t nrow_ghost = (nx+2*ng)*(ny+2*ng)*(nz+2*ng); // local number of rows *including* ghost points
   double* xg = new double[nrow_ghost]; // Copy of x with ghost points
 
-  // Copy xv to xg
+  // Copy xv to xg TODO HACK fix this
   for (local_int_t ix=0; ix<nx; ++ix) {
     for (local_int_t iy=0; iy<ny; ++iy) {
       for (local_int_t iz=0; iz<nz; ++iz) {
@@ -97,6 +98,8 @@ int ComputeSPMV_ref( const SparseMatrix & A, Vector & x, Vector & y) {
       }
     }
   }
+
+  delete[] xg;
 
   return 0;
 }

--- a/src/ComputeSPMV_ref.cpp
+++ b/src/ComputeSPMV_ref.cpp
@@ -32,7 +32,8 @@
 // FIXME put me somewhere sensible
 inline int idx(const int ix, const int iy, const int iz, const int nx, const int ny, const int nz, const int ng=0) {
   // input index of (0, 0, 0) corresponds to first *interior* point. Ghost points are accessed with (-1, -1, -1).
-  return (iz+ng)*(nx+2*ng)*(ny+2*ng)+(iy+ng)*(nx+2*ng)+(ix+ng);
+  //return (iz+ng)*(nx+2*ng)*(ny+2*ng)+(iy+ng)*(nx+2*ng)+(ix+ng);
+  return (ix+ng)*(nz+2*ng)*(ny+2*ng)+(iy+ng)*(nz+2*ng)+(iz+ng);
 }
 
 /*!
@@ -56,6 +57,7 @@ int ComputeSPMV_ref( const SparseMatrix & A, Vector & x, Vector & y) {
   assert(y.localLength>=A.localNumberOfRows);
 
 #ifndef HPCG_NO_MPI
+    // TODO MPI is not implemented yet
     ExchangeHalo(A,x);
 #endif
   const double * const xv = x.values;
@@ -67,9 +69,9 @@ int ComputeSPMV_ref( const SparseMatrix & A, Vector & x, Vector & y) {
   global_int_t nz = A.geom->nz;
   global_int_t ng = 1; // number of ghost points
   const local_int_t nrow_ghost = (nx+2*ng)*(ny+2*ng)*(nz+2*ng); // local number of rows *including* ghost points
-  double* xg = new double[nrow_ghost]; // Copy of x with ghost points
+  double* xg = new double[nrow_ghost]{0.0}; // Copy of x with ghost points
 
-  // Copy xv to xg TODO HACK fix this
+  // Copy xv to xg TODO HACK find better way to do this
   for (local_int_t ix=0; ix<nx; ++ix) {
     for (local_int_t iy=0; iy<ny; ++iy) {
       for (local_int_t iz=0; iz<nz; ++iz) {

--- a/src/ComputeSYMGS_ref.cpp
+++ b/src/ComputeSYMGS_ref.cpp
@@ -27,7 +27,8 @@
 // FIXME put me somewhere sensible
 inline int idx(const int ix, const int iy, const int iz, const int nx, const int ny, const int nz, const int ng=0) {
   // input index of (0, 0, 0) corresponds to first *interior* point. Ghost points are accessed with (-1, -1, -1).
-  return (iz+ng)*(nx+2*ng)*(ny+2*ng)+(iy+ng)*(nx+2*ng)+(ix+ng);
+  //return (iz+ng)*(nx+2*ng)*(ny+2*ng)+(iy+ng)*(nx+2*ng)+(ix+ng);
+  return (ix+ng)*(nz+2*ng)*(ny+2*ng)+(iy+ng)*(nz+2*ng)+(iz+ng);
 }
 
 /*!
@@ -65,17 +66,15 @@ int ComputeSYMGS_ref( const SparseMatrix & A, const Vector & r, Vector & x) {
   ExchangeHalo(A,x);
 #endif
 
-  //const local_int_t nrow = A.localNumberOfRows;
-  //double ** matrixDiagonal = A.matrixDiagonal;  // An array of pointers to the diagonal entries A.matrixValues
   const double * const rv = r.values;
   double * const xv = x.values;
 
   global_int_t nx = A.geom->nx;
   global_int_t ny = A.geom->ny;
   global_int_t nz = A.geom->nz;
-  global_int_t ng = 1; // number of ghost points
+  global_int_t ng = 1; // number of ghost points FIXME should be declared "more globally"
   const local_int_t nrow_ghost = (nx+2*ng)*(ny+2*ng)*(nz+2*ng); // local number of rows *including* ghost points
-  double* xg = new double[nrow_ghost]; // Copy of x with ghost points
+  double* xg = new double[nrow_ghost]{0.0}; // Copy of x with ghost points
 
   // copy xv to xg TODO HACK fix this
   for (local_int_t ix=0; ix<nx; ++ix) {

--- a/src/ComputeSYMGS_ref.cpp
+++ b/src/ComputeSYMGS_ref.cpp
@@ -66,70 +66,110 @@ int ComputeSYMGS_ref( const SparseMatrix & A, const Vector & r, Vector & x) {
   ExchangeHalo(A,x);
 #endif
 
+  const local_int_t nrow = A.localNumberOfRows;
+  double ** matrixDiagonal = A.matrixDiagonal;  // An array of pointers to the diagonal entries A.matrixValues
   const double * const rv = r.values;
   double * const xv = x.values;
 
-  global_int_t nx = A.geom->nx;
-  global_int_t ny = A.geom->ny;
-  global_int_t nz = A.geom->nz;
-  global_int_t ng = 1; // number of ghost points FIXME should be declared "more globally"
-  const local_int_t nrow_ghost = (nx+2*ng)*(ny+2*ng)*(nz+2*ng); // local number of rows *including* ghost points
-  double* xg = new double[nrow_ghost]{0.0}; // Copy of x with ghost points
+  for (local_int_t i=0; i< nrow; i++) {
+    const double * const currentValues = A.matrixValues[i];
+    const local_int_t * const currentColIndices = A.mtxIndL[i];
+    const int currentNumberOfNonzeros = A.nonzerosInRow[i];
+    const double  currentDiagonal = matrixDiagonal[i][0]; // Current diagonal value
+    double sum = rv[i]; // RHS value
 
-  // copy xv to xg TODO HACK fix this
-  for (local_int_t ix=0; ix<nx; ++ix) {
-    for (local_int_t iy=0; iy<ny; ++iy) {
-      for (local_int_t iz=0; iz<nz; ++iz) {
-        xg[idx(ix,iy,iz,nx,ny,nz,ng)] = xv[idx(ix,iy,iz,nx,ny,nz)];
-      }
+    for (int j=0; j< currentNumberOfNonzeros; j++) {
+      local_int_t curCol = currentColIndices[j];
+      sum -= currentValues[j] * xv[curCol];
     }
+    sum += xv[i]*currentDiagonal; // Remove diagonal contribution from previous loop
+
+    xv[i] = sum/currentDiagonal;
+
   }
 
-  const double currentDiagonal = 26.0; // Current diagonal value CHANGEME when changing stencil
+  // Now the back sweep.
 
-#ifndef HPCG_NO_OPENMP
-  #pragma omp parallel for
-#endif
-  for (local_int_t ix=0; ix<nx; ++ix) {
-    for (local_int_t iy=0; iy<ny; ++iy) {
-      for (local_int_t iz=0; iz<nz; ++iz) {
-        double sum = rv[idx(ix,iy,iz,nx,ny,nz)]; // RHS value
-        for(int sx=-1; sx<=1; ++sx) {
-          for(int sy=-1; sy<=1; ++sy) {
-            for(int sz=-1; sz<=1; ++sz) {
-              sum -= -1.*xg[idx(ix+sx, iy+sy, iz+sz, nx, ny, nz, ng)];
-            }
-          }
-        }
-        sum += -1.*xg[idx(ix+0, iy+0, iz+0, nx, ny, nz, ng)]; // Remove diagnoal component entirely
+  for (local_int_t i=nrow-1; i>=0; i--) {
+    const double * const currentValues = A.matrixValues[i];
+    const local_int_t * const currentColIndices = A.mtxIndL[i];
+    const int currentNumberOfNonzeros = A.nonzerosInRow[i];
+    const double  currentDiagonal = matrixDiagonal[i][0]; // Current diagonal value
+    double sum = rv[i]; // RHS value
 
-        xg[idx(ix,iy,iz,nx,ny,nz,ng)] = sum/currentDiagonal;
-      }
+    for (int j = 0; j< currentNumberOfNonzeros; j++) {
+      local_int_t curCol = currentColIndices[j];
+      sum -= currentValues[j]*xv[curCol];
     }
+    sum += xv[i]*currentDiagonal; // Remove diagonal contribution from previous loop
+
+    xv[i] = sum/currentDiagonal;
   }
 
-#ifndef HPCG_NO_OPENMP
-  #pragma omp parallel for
-#endif
-  for (local_int_t ix=nx-1; ix>=0; --ix) {
-    for (local_int_t iy=ny-1; iy>=0; --iy) {
-      for (local_int_t iz=nz-1; iz>=0; --iz) {
-        double sum = rv[idx(ix,iy,iz,nx,ny,nz)]; // RHS value
-        for(int sx=-1; sx<=1; ++sx) {
-          for(int sy=-1; sy<=1; ++sy) {
-            for(int sz=-1; sz<=1; ++sz) {
-              sum -= -1.*xg[idx(ix+sx, iy+sy, iz+sz, nx, ny, nz, ng)];
-            }
-          }
-        }
-        sum += -1.*xg[idx(ix+0, iy+0, iz+0, nx, ny, nz, ng)]; // Remove diagnoal component entirely
+  //const double * const rv = r.values;
+  //double * const xv = x.values;
 
-        xv[idx(ix,iy,iz,nx,ny,nz)] = sum/currentDiagonal;
-      }
-    }
-  }
+  //global_int_t nx = A.geom->nx;
+  //global_int_t ny = A.geom->ny;
+  //global_int_t nz = A.geom->nz;
+  //global_int_t ng = 1; // number of ghost points FIXME should be declared "more globally"
+  //const local_int_t nrow_ghost = (nx+2*ng)*(ny+2*ng)*(nz+2*ng); // local number of rows *including* ghost points
+  //double* xg = new double[nrow_ghost]{0.0}; // Copy of x with ghost points
 
-  delete[] xg;
+  //// copy xv to xg TODO HACK fix this
+  //for (local_int_t ix=0; ix<nx; ++ix) {
+    //for (local_int_t iy=0; iy<ny; ++iy) {
+      //for (local_int_t iz=0; iz<nz; ++iz) {
+        //xg[idx(ix,iy,iz,nx,ny,nz,ng)] = xv[idx(ix,iy,iz,nx,ny,nz)];
+      //}
+    //}
+  //}
+
+  //const double currentDiagonal = 26.0; // Current diagonal value CHANGEME when changing stencil
+
+//#ifndef HPCG_NO_OPENMP
+  //#pragma omp parallel for
+//#endif
+  //for (local_int_t ix=0; ix<nx; ++ix) {
+    //for (local_int_t iy=0; iy<ny; ++iy) {
+      //for (local_int_t iz=0; iz<nz; ++iz) {
+        //double sum = rv[idx(ix,iy,iz,nx,ny,nz)]; // RHS value
+        //for(int sx=-1; sx<=1; ++sx) {
+          //for(int sy=-1; sy<=1; ++sy) {
+            //for(int sz=-1; sz<=1; ++sz) {
+              //sum -= -1.*xg[idx(ix+sx, iy+sy, iz+sz, nx, ny, nz, ng)];
+            //}
+          //}
+        //}
+        //sum += -1.*xg[idx(ix+0, iy+0, iz+0, nx, ny, nz, ng)]; // Remove diagnoal component entirely
+
+        //xg[idx(ix,iy,iz,nx,ny,nz,ng)] = sum/currentDiagonal;
+      //}
+    //}
+  //}
+
+//#ifndef HPCG_NO_OPENMP
+  //#pragma omp parallel for
+//#endif
+  //for (local_int_t ix=nx-1; ix>=0; --ix) {
+    //for (local_int_t iy=ny-1; iy>=0; --iy) {
+      //for (local_int_t iz=nz-1; iz>=0; --iz) {
+        //double sum = rv[idx(ix,iy,iz,nx,ny,nz)]; // RHS value
+        //for(int sx=-1; sx<=1; ++sx) {
+          //for(int sy=-1; sy<=1; ++sy) {
+            //for(int sz=-1; sz<=1; ++sz) {
+              //sum -= -1.*xg[idx(ix+sx, iy+sy, iz+sz, nx, ny, nz, ng)];
+            //}
+          //}
+        //}
+        //sum += -1.*xg[idx(ix+0, iy+0, iz+0, nx, ny, nz, ng)]; // Remove diagnoal component entirely
+
+        //xv[idx(ix,iy,iz,nx,ny,nz)] = sum/currentDiagonal;
+      //}
+    //}
+  //}
+
+  //delete[] xg;
 
   return 0;
 }

--- a/src/ComputeSYMGS_ref.cpp
+++ b/src/ComputeSYMGS_ref.cpp
@@ -61,114 +61,114 @@ int ComputeSYMGS_ref( const SparseMatrix & A, const Vector & r, Vector & x) {
   ExchangeHalo(A,x);
 #endif
 
-  //const local_int_t nrow = A.localNumberOfRows;
-  //double ** matrixDiagonal = A.matrixDiagonal;  // An array of pointers to the diagonal entries A.matrixValues
-  //const double * const rv = r.values;
-  //double * const xv = x.values;
-
-  //for (local_int_t i=0; i< nrow; i++) {
-    //const double * const currentValues = A.matrixValues[i];
-    //const local_int_t * const currentColIndices = A.mtxIndL[i];
-    //const int currentNumberOfNonzeros = A.nonzerosInRow[i];
-    //const double  currentDiagonal = matrixDiagonal[i][0]; // Current diagonal value
-    //double sum = rv[i]; // RHS value
-
-    //for (int j=0; j< currentNumberOfNonzeros; j++) {
-      //local_int_t curCol = currentColIndices[j];
-      //sum -= currentValues[j] * xv[curCol];
-    //}
-    //sum += xv[i]*currentDiagonal; // Remove diagonal contribution from previous loop
-
-    //xv[i] = sum/currentDiagonal;
-
-  //}
-
-  //// Now the back sweep.
-
-  //for (local_int_t i=nrow-1; i>=0; i--) {
-    //const double * const currentValues = A.matrixValues[i];
-    //const local_int_t * const currentColIndices = A.mtxIndL[i];
-    //const int currentNumberOfNonzeros = A.nonzerosInRow[i];
-    //const double  currentDiagonal = matrixDiagonal[i][0]; // Current diagonal value
-    //double sum = rv[i]; // RHS value
-
-    //for (int j = 0; j< currentNumberOfNonzeros; j++) {
-      //local_int_t curCol = currentColIndices[j];
-      //sum -= currentValues[j]*xv[curCol];
-    //}
-    //sum += xv[i]*currentDiagonal; // Remove diagonal contribution from previous loop
-
-    //xv[i] = sum/currentDiagonal;
-  //}
-
-////////////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////////////////
-
+  const local_int_t nrow = A.localNumberOfRows;
+  double ** matrixDiagonal = A.matrixDiagonal;  // An array of pointers to the diagonal entries A.matrixValues
   const double * const rv = r.values;
   double * const xv = x.values;
 
-  global_int_t nx = A.geom->nx;
-  global_int_t ny = A.geom->ny;
-  global_int_t nz = A.geom->nz;
-  global_int_t ng = 1; // number of ghost points FIXME should be declared "more globally"
-  const local_int_t nrow_ghost = (nx+2*ng)*(ny+2*ng)*(nz+2*ng); // local number of rows *including* ghost points
-  double* xg = new double[nrow_ghost]{0.0}; // Copy of x with ghost points
+  for (local_int_t i=0; i< nrow; i++) {
+    const double * const currentValues = A.matrixValues[i];
+    const local_int_t * const currentColIndices = A.mtxIndL[i];
+    const int currentNumberOfNonzeros = A.nonzerosInRow[i];
+    const double  currentDiagonal = matrixDiagonal[i][0]; // Current diagonal value
+    double sum = rv[i]; // RHS value
 
-  // copy xv to xg TODO HACK fix this
-  for (local_int_t ix=0; ix<nx; ++ix) {
-    for (local_int_t iy=0; iy<ny; ++iy) {
-      for (local_int_t iz=0; iz<nz; ++iz) {
-        xg[idx(ix,iy,iz,nx,ny,nz,ng)] = xv[idx(ix,iy,iz,nx,ny,nz)];
-      }
+    for (int j=0; j< currentNumberOfNonzeros; j++) {
+      local_int_t curCol = currentColIndices[j];
+      sum -= currentValues[j] * xv[curCol];
     }
+    sum += xv[i]*currentDiagonal; // Remove diagonal contribution from previous loop
+
+    xv[i] = sum/currentDiagonal;
+
   }
 
-  const double currentDiagonal = 26.0; // Current diagonal value CHANGEME when changing stencil
+  // Now the back sweep.
 
-#ifndef HPCG_NO_OPENMP
-  #pragma omp parallel for
-#endif
-  for (local_int_t ix=0; ix<nx; ++ix) {
-    for (local_int_t iy=0; iy<ny; ++iy) {
-      for (local_int_t iz=0; iz<nz; ++iz) {
-        double sum = rv[idx(ix,iy,iz,nx,ny,nz)]; // RHS value
-        for(int sx=-1; sx<=1; ++sx) {
-          for(int sy=-1; sy<=1; ++sy) {
-            for(int sz=-1; sz<=1; ++sz) {
-              sum -= -1.*xg[idx(ix+sx, iy+sy, iz+sz, nx, ny, nz, ng)];
-            }
-          }
-        }
-        sum += -1.*xg[idx(ix+0, iy+0, iz+0, nx, ny, nz, ng)]; // Remove diagnoal component entirely
+  for (local_int_t i=nrow-1; i>=0; i--) {
+    const double * const currentValues = A.matrixValues[i];
+    const local_int_t * const currentColIndices = A.mtxIndL[i];
+    const int currentNumberOfNonzeros = A.nonzerosInRow[i];
+    const double  currentDiagonal = matrixDiagonal[i][0]; // Current diagonal value
+    double sum = rv[i]; // RHS value
 
-        xg[idx(ix,iy,iz,nx,ny,nz,ng)] = sum/currentDiagonal;
-      }
+    for (int j = 0; j< currentNumberOfNonzeros; j++) {
+      local_int_t curCol = currentColIndices[j];
+      sum -= currentValues[j]*xv[curCol];
     }
+    sum += xv[i]*currentDiagonal; // Remove diagonal contribution from previous loop
+
+    xv[i] = sum/currentDiagonal;
   }
 
-#ifndef HPCG_NO_OPENMP
-  #pragma omp parallel for
-#endif
-  for (local_int_t ix=nx-1; ix>=0; --ix) {
-    for (local_int_t iy=ny-1; iy>=0; --iy) {
-      for (local_int_t iz=nz-1; iz>=0; --iz) {
-        double sum = rv[idx(ix,iy,iz,nx,ny,nz)]; // RHS value
-        for(int sx=-1; sx<=1; ++sx) {
-          for(int sy=-1; sy<=1; ++sy) {
-            for(int sz=-1; sz<=1; ++sz) {
-              sum -= -1.*xg[idx(ix+sx, iy+sy, iz+sz, nx, ny, nz, ng)];
-            }
-          }
-        }
-        sum += -1.*xg[idx(ix+0, iy+0, iz+0, nx, ny, nz, ng)]; // Remove diagnoal component entirely
+////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////
 
-        xv[idx(ix,iy,iz,nx,ny,nz)] = sum/currentDiagonal;
-      }
-    }
-  }
+  //const double * const rv = r.values;
+  //double * const xv = x.values;
 
-  delete[] xg;
+  //global_int_t nx = A.geom->nx;
+  //global_int_t ny = A.geom->ny;
+  //global_int_t nz = A.geom->nz;
+  //global_int_t ng = 1; // number of ghost points FIXME should be declared "more globally"
+  //const local_int_t nrow_ghost = (nx+2*ng)*(ny+2*ng)*(nz+2*ng); // local number of rows *including* ghost points
+  //double* xg = new double[nrow_ghost]{0.0}; // Copy of x with ghost points
+
+  //// copy xv to xg TODO HACK fix this
+  //for (local_int_t ix=0; ix<nx; ++ix) {
+    //for (local_int_t iy=0; iy<ny; ++iy) {
+      //for (local_int_t iz=0; iz<nz; ++iz) {
+        //xg[idx(ix,iy,iz,nx,ny,nz,ng)] = xv[idx(ix,iy,iz,nx,ny,nz)];
+      //}
+    //}
+  //}
+
+  //const double currentDiagonal = 26.0; // Current diagonal value CHANGEME when changing stencil
+
+//#ifndef HPCG_NO_OPENMP
+  //#pragma omp parallel for
+//#endif
+  //for (local_int_t ix=0; ix<nx; ++ix) {
+    //for (local_int_t iy=0; iy<ny; ++iy) {
+      //for (local_int_t iz=0; iz<nz; ++iz) {
+        //double sum = rv[idx(ix,iy,iz,nx,ny,nz)]; // RHS value
+        //for(int sx=-1; sx<=1; ++sx) {
+          //for(int sy=-1; sy<=1; ++sy) {
+            //for(int sz=-1; sz<=1; ++sz) {
+              //sum -= -1.*xg[idx(ix+sx, iy+sy, iz+sz, nx, ny, nz, ng)];
+            //}
+          //}
+        //}
+        //sum += -1.*xg[idx(ix+0, iy+0, iz+0, nx, ny, nz, ng)]; // Remove diagnoal component entirely
+
+        //xg[idx(ix,iy,iz,nx,ny,nz,ng)] = sum/currentDiagonal;
+      //}
+    //}
+  //}
+
+//#ifndef HPCG_NO_OPENMP
+  //#pragma omp parallel for
+//#endif
+  //for (local_int_t ix=nx-1; ix>=0; --ix) {
+    //for (local_int_t iy=ny-1; iy>=0; --iy) {
+      //for (local_int_t iz=nz-1; iz>=0; --iz) {
+        //double sum = rv[idx(ix,iy,iz,nx,ny,nz)]; // RHS value
+        //for(int sx=-1; sx<=1; ++sx) {
+          //for(int sy=-1; sy<=1; ++sy) {
+            //for(int sz=-1; sz<=1; ++sz) {
+              //sum -= -1.*xg[idx(ix+sx, iy+sy, iz+sz, nx, ny, nz, ng)];
+            //}
+          //}
+        //}
+        //sum += -1.*xg[idx(ix+0, iy+0, iz+0, nx, ny, nz, ng)]; // Remove diagnoal component entirely
+
+        //xv[idx(ix,iy,iz,nx,ny,nz)] = sum/currentDiagonal;
+      //}
+    //}
+  //}
+
+  //delete[] xg;
 
   return 0;
 }

--- a/src/ComputeSYMGS_ref.cpp
+++ b/src/ComputeSYMGS_ref.cpp
@@ -21,15 +21,10 @@
 #ifndef HPCG_NO_MPI
 #include "ExchangeHalo.hpp"
 #endif
+#include "idx.hpp"
 #include "ComputeSYMGS_ref.hpp"
 #include <cassert>
 
-// FIXME put me somewhere sensible
-inline int idx(const int ix, const int iy, const int iz, const int nx, const int ny, const int nz, const int ng=0) {
-  // input index of (0, 0, 0) corresponds to first *interior* point. Ghost points are accessed with (-1, -1, -1).
-  //return (iz+ng)*(nx+2*ng)*(ny+2*ng)+(iy+ng)*(nx+2*ng)+(ix+ng);
-  return (ix+ng)*(nz+2*ng)*(ny+2*ng)+(iy+ng)*(nz+2*ng)+(iz+ng);
-}
 
 /*!
   Computes one step of symmetric Gauss-Seidel:
@@ -66,110 +61,114 @@ int ComputeSYMGS_ref( const SparseMatrix & A, const Vector & r, Vector & x) {
   ExchangeHalo(A,x);
 #endif
 
-  const local_int_t nrow = A.localNumberOfRows;
-  double ** matrixDiagonal = A.matrixDiagonal;  // An array of pointers to the diagonal entries A.matrixValues
-  const double * const rv = r.values;
-  double * const xv = x.values;
-
-  for (local_int_t i=0; i< nrow; i++) {
-    const double * const currentValues = A.matrixValues[i];
-    const local_int_t * const currentColIndices = A.mtxIndL[i];
-    const int currentNumberOfNonzeros = A.nonzerosInRow[i];
-    const double  currentDiagonal = matrixDiagonal[i][0]; // Current diagonal value
-    double sum = rv[i]; // RHS value
-
-    for (int j=0; j< currentNumberOfNonzeros; j++) {
-      local_int_t curCol = currentColIndices[j];
-      sum -= currentValues[j] * xv[curCol];
-    }
-    sum += xv[i]*currentDiagonal; // Remove diagonal contribution from previous loop
-
-    xv[i] = sum/currentDiagonal;
-
-  }
-
-  // Now the back sweep.
-
-  for (local_int_t i=nrow-1; i>=0; i--) {
-    const double * const currentValues = A.matrixValues[i];
-    const local_int_t * const currentColIndices = A.mtxIndL[i];
-    const int currentNumberOfNonzeros = A.nonzerosInRow[i];
-    const double  currentDiagonal = matrixDiagonal[i][0]; // Current diagonal value
-    double sum = rv[i]; // RHS value
-
-    for (int j = 0; j< currentNumberOfNonzeros; j++) {
-      local_int_t curCol = currentColIndices[j];
-      sum -= currentValues[j]*xv[curCol];
-    }
-    sum += xv[i]*currentDiagonal; // Remove diagonal contribution from previous loop
-
-    xv[i] = sum/currentDiagonal;
-  }
-
+  //const local_int_t nrow = A.localNumberOfRows;
+  //double ** matrixDiagonal = A.matrixDiagonal;  // An array of pointers to the diagonal entries A.matrixValues
   //const double * const rv = r.values;
   //double * const xv = x.values;
 
-  //global_int_t nx = A.geom->nx;
-  //global_int_t ny = A.geom->ny;
-  //global_int_t nz = A.geom->nz;
-  //global_int_t ng = 1; // number of ghost points FIXME should be declared "more globally"
-  //const local_int_t nrow_ghost = (nx+2*ng)*(ny+2*ng)*(nz+2*ng); // local number of rows *including* ghost points
-  //double* xg = new double[nrow_ghost]{0.0}; // Copy of x with ghost points
+  //for (local_int_t i=0; i< nrow; i++) {
+    //const double * const currentValues = A.matrixValues[i];
+    //const local_int_t * const currentColIndices = A.mtxIndL[i];
+    //const int currentNumberOfNonzeros = A.nonzerosInRow[i];
+    //const double  currentDiagonal = matrixDiagonal[i][0]; // Current diagonal value
+    //double sum = rv[i]; // RHS value
 
-  //// copy xv to xg TODO HACK fix this
-  //for (local_int_t ix=0; ix<nx; ++ix) {
-    //for (local_int_t iy=0; iy<ny; ++iy) {
-      //for (local_int_t iz=0; iz<nz; ++iz) {
-        //xg[idx(ix,iy,iz,nx,ny,nz,ng)] = xv[idx(ix,iy,iz,nx,ny,nz)];
-      //}
+    //for (int j=0; j< currentNumberOfNonzeros; j++) {
+      //local_int_t curCol = currentColIndices[j];
+      //sum -= currentValues[j] * xv[curCol];
     //}
+    //sum += xv[i]*currentDiagonal; // Remove diagonal contribution from previous loop
+
+    //xv[i] = sum/currentDiagonal;
+
   //}
 
-  //const double currentDiagonal = 26.0; // Current diagonal value CHANGEME when changing stencil
+  //// Now the back sweep.
 
-//#ifndef HPCG_NO_OPENMP
-  //#pragma omp parallel for
-//#endif
-  //for (local_int_t ix=0; ix<nx; ++ix) {
-    //for (local_int_t iy=0; iy<ny; ++iy) {
-      //for (local_int_t iz=0; iz<nz; ++iz) {
-        //double sum = rv[idx(ix,iy,iz,nx,ny,nz)]; // RHS value
-        //for(int sx=-1; sx<=1; ++sx) {
-          //for(int sy=-1; sy<=1; ++sy) {
-            //for(int sz=-1; sz<=1; ++sz) {
-              //sum -= -1.*xg[idx(ix+sx, iy+sy, iz+sz, nx, ny, nz, ng)];
-            //}
-          //}
-        //}
-        //sum += -1.*xg[idx(ix+0, iy+0, iz+0, nx, ny, nz, ng)]; // Remove diagnoal component entirely
+  //for (local_int_t i=nrow-1; i>=0; i--) {
+    //const double * const currentValues = A.matrixValues[i];
+    //const local_int_t * const currentColIndices = A.mtxIndL[i];
+    //const int currentNumberOfNonzeros = A.nonzerosInRow[i];
+    //const double  currentDiagonal = matrixDiagonal[i][0]; // Current diagonal value
+    //double sum = rv[i]; // RHS value
 
-        //xg[idx(ix,iy,iz,nx,ny,nz,ng)] = sum/currentDiagonal;
-      //}
+    //for (int j = 0; j< currentNumberOfNonzeros; j++) {
+      //local_int_t curCol = currentColIndices[j];
+      //sum -= currentValues[j]*xv[curCol];
     //}
+    //sum += xv[i]*currentDiagonal; // Remove diagonal contribution from previous loop
+
+    //xv[i] = sum/currentDiagonal;
   //}
 
-//#ifndef HPCG_NO_OPENMP
-  //#pragma omp parallel for
-//#endif
-  //for (local_int_t ix=nx-1; ix>=0; --ix) {
-    //for (local_int_t iy=ny-1; iy>=0; --iy) {
-      //for (local_int_t iz=nz-1; iz>=0; --iz) {
-        //double sum = rv[idx(ix,iy,iz,nx,ny,nz)]; // RHS value
-        //for(int sx=-1; sx<=1; ++sx) {
-          //for(int sy=-1; sy<=1; ++sy) {
-            //for(int sz=-1; sz<=1; ++sz) {
-              //sum -= -1.*xg[idx(ix+sx, iy+sy, iz+sz, nx, ny, nz, ng)];
-            //}
-          //}
-        //}
-        //sum += -1.*xg[idx(ix+0, iy+0, iz+0, nx, ny, nz, ng)]; // Remove diagnoal component entirely
+////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////
 
-        //xv[idx(ix,iy,iz,nx,ny,nz)] = sum/currentDiagonal;
-      //}
-    //}
-  //}
+  const double * const rv = r.values;
+  double * const xv = x.values;
 
-  //delete[] xg;
+  global_int_t nx = A.geom->nx;
+  global_int_t ny = A.geom->ny;
+  global_int_t nz = A.geom->nz;
+  global_int_t ng = 1; // number of ghost points FIXME should be declared "more globally"
+  const local_int_t nrow_ghost = (nx+2*ng)*(ny+2*ng)*(nz+2*ng); // local number of rows *including* ghost points
+  double* xg = new double[nrow_ghost]{0.0}; // Copy of x with ghost points
+
+  // copy xv to xg TODO HACK fix this
+  for (local_int_t ix=0; ix<nx; ++ix) {
+    for (local_int_t iy=0; iy<ny; ++iy) {
+      for (local_int_t iz=0; iz<nz; ++iz) {
+        xg[idx(ix,iy,iz,nx,ny,nz,ng)] = xv[idx(ix,iy,iz,nx,ny,nz)];
+      }
+    }
+  }
+
+  const double currentDiagonal = 26.0; // Current diagonal value CHANGEME when changing stencil
+
+#ifndef HPCG_NO_OPENMP
+  #pragma omp parallel for
+#endif
+  for (local_int_t ix=0; ix<nx; ++ix) {
+    for (local_int_t iy=0; iy<ny; ++iy) {
+      for (local_int_t iz=0; iz<nz; ++iz) {
+        double sum = rv[idx(ix,iy,iz,nx,ny,nz)]; // RHS value
+        for(int sx=-1; sx<=1; ++sx) {
+          for(int sy=-1; sy<=1; ++sy) {
+            for(int sz=-1; sz<=1; ++sz) {
+              sum -= -1.*xg[idx(ix+sx, iy+sy, iz+sz, nx, ny, nz, ng)];
+            }
+          }
+        }
+        sum += -1.*xg[idx(ix+0, iy+0, iz+0, nx, ny, nz, ng)]; // Remove diagnoal component entirely
+
+        xg[idx(ix,iy,iz,nx,ny,nz,ng)] = sum/currentDiagonal;
+      }
+    }
+  }
+
+#ifndef HPCG_NO_OPENMP
+  #pragma omp parallel for
+#endif
+  for (local_int_t ix=nx-1; ix>=0; --ix) {
+    for (local_int_t iy=ny-1; iy>=0; --iy) {
+      for (local_int_t iz=nz-1; iz>=0; --iz) {
+        double sum = rv[idx(ix,iy,iz,nx,ny,nz)]; // RHS value
+        for(int sx=-1; sx<=1; ++sx) {
+          for(int sy=-1; sy<=1; ++sy) {
+            for(int sz=-1; sz<=1; ++sz) {
+              sum -= -1.*xg[idx(ix+sx, iy+sy, iz+sz, nx, ny, nz, ng)];
+            }
+          }
+        }
+        sum += -1.*xg[idx(ix+0, iy+0, iz+0, nx, ny, nz, ng)]; // Remove diagnoal component entirely
+
+        xv[idx(ix,iy,iz,nx,ny,nz)] = sum/currentDiagonal;
+      }
+    }
+  }
+
+  delete[] xg;
 
   return 0;
 }

--- a/src/ComputeSYMGS_ref.cpp
+++ b/src/ComputeSYMGS_ref.cpp
@@ -65,7 +65,7 @@ int ComputeSYMGS_ref( const SparseMatrix & A, const Vector & r, Vector & x) {
   ExchangeHalo(A,x);
 #endif
 
-  const local_int_t nrow = A.localNumberOfRows;
+  //const local_int_t nrow = A.localNumberOfRows;
   //double ** matrixDiagonal = A.matrixDiagonal;  // An array of pointers to the diagonal entries A.matrixValues
   const double * const rv = r.values;
   double * const xv = x.values;
@@ -86,7 +86,7 @@ int ComputeSYMGS_ref( const SparseMatrix & A, const Vector & r, Vector & x) {
     }
   }
 
-  const double  currentDiagonal = 26.0; // Current diagonal value CHANGEME when changing stencil
+  const double currentDiagonal = 26.0; // Current diagonal value CHANGEME when changing stencil
 
 #ifndef HPCG_NO_OPENMP
   #pragma omp parallel for
@@ -104,7 +104,7 @@ int ComputeSYMGS_ref( const SparseMatrix & A, const Vector & r, Vector & x) {
         }
         sum += -1.*xg[idx(ix+0, iy+0, iz+0, nx, ny, nz, ng)]; // Remove diagnoal component entirely
 
-        xg[idx(ix,iy,iz,nx,ny,nz)] = sum/currentDiagonal;
+        xg[idx(ix,iy,iz,nx,ny,nz,ng)] = sum/currentDiagonal;
       }
     }
   }
@@ -116,9 +116,9 @@ int ComputeSYMGS_ref( const SparseMatrix & A, const Vector & r, Vector & x) {
     for (local_int_t iy=ny-1; iy>=0; --iy) {
       for (local_int_t iz=nz-1; iz>=0; --iz) {
         double sum = rv[idx(ix,iy,iz,nx,ny,nz)]; // RHS value
-        for(int sx=1; sx>=-1; --sx) {
-          for(int sy=1; sy>=-1; --sy) {
-            for(int sz=1; sz>=-1; --sz) {
+        for(int sx=-1; sx<=1; ++sx) {
+          for(int sy=-1; sy<=1; ++sy) {
+            for(int sz=-1; sz<=1; ++sz) {
               sum -= -1.*xg[idx(ix+sx, iy+sy, iz+sz, nx, ny, nz, ng)];
             }
           }

--- a/src/ComputeSYMGS_ref.cpp
+++ b/src/ComputeSYMGS_ref.cpp
@@ -24,6 +24,12 @@
 #include "ComputeSYMGS_ref.hpp"
 #include <cassert>
 
+// FIXME put me somewhere sensible
+inline int idx(const int ix, const int iy, const int iz, const int nx, const int ny, const int nz, const int ng=0) {
+  // input index of (0, 0, 0) corresponds to first *interior* point. Ghost points are accessed with (-1, -1, -1).
+  return (iz+ng)*(nx+2*ng)*(ny+2*ng)+(iy+ng)*(nx+2*ng)+(ix+ng);
+}
+
 /*!
   Computes one step of symmetric Gauss-Seidel:
 
@@ -60,44 +66,71 @@ int ComputeSYMGS_ref( const SparseMatrix & A, const Vector & r, Vector & x) {
 #endif
 
   const local_int_t nrow = A.localNumberOfRows;
-  double ** matrixDiagonal = A.matrixDiagonal;  // An array of pointers to the diagonal entries A.matrixValues
+  //double ** matrixDiagonal = A.matrixDiagonal;  // An array of pointers to the diagonal entries A.matrixValues
   const double * const rv = r.values;
   double * const xv = x.values;
 
-  for (local_int_t i=0; i< nrow; i++) {
-    const double * const currentValues = A.matrixValues[i];
-    const local_int_t * const currentColIndices = A.mtxIndL[i];
-    const int currentNumberOfNonzeros = A.nonzerosInRow[i];
-    const double  currentDiagonal = matrixDiagonal[i][0]; // Current diagonal value
-    double sum = rv[i]; // RHS value
+  global_int_t nx = A.geom->nx;
+  global_int_t ny = A.geom->ny;
+  global_int_t nz = A.geom->nz;
+  global_int_t ng = 1; // number of ghost points
+  const local_int_t nrow_ghost = (nx+2*ng)*(ny+2*ng)*(nz+2*ng); // local number of rows *including* ghost points
+  double* xg = new double[nrow_ghost]; // Copy of x with ghost points
 
-    for (int j=0; j< currentNumberOfNonzeros; j++) {
-      local_int_t curCol = currentColIndices[j];
-      sum -= currentValues[j] * xv[curCol];
+  // copy xv to xg TODO HACK fix this
+  for (local_int_t ix=0; ix<nx; ++ix) {
+    for (local_int_t iy=0; iy<ny; ++iy) {
+      for (local_int_t iz=0; iz<nz; ++iz) {
+        xg[idx(ix,iy,iz,nx,ny,nz,ng)] = xv[idx(ix,iy,iz,nx,ny,nz)];
+      }
     }
-    sum += xv[i]*currentDiagonal; // Remove diagonal contribution from previous loop
-
-    xv[i] = sum/currentDiagonal;
-
   }
 
-  // Now the back sweep.
+  const double  currentDiagonal = 26.0; // Current diagonal value CHANGEME when changing stencil
 
-  for (local_int_t i=nrow-1; i>=0; i--) {
-    const double * const currentValues = A.matrixValues[i];
-    const local_int_t * const currentColIndices = A.mtxIndL[i];
-    const int currentNumberOfNonzeros = A.nonzerosInRow[i];
-    const double  currentDiagonal = matrixDiagonal[i][0]; // Current diagonal value
-    double sum = rv[i]; // RHS value
+#ifndef HPCG_NO_OPENMP
+  #pragma omp parallel for
+#endif
+  for (local_int_t ix=0; ix<nx; ++ix) {
+    for (local_int_t iy=0; iy<ny; ++iy) {
+      for (local_int_t iz=0; iz<nz; ++iz) {
+        double sum = rv[idx(ix,iy,iz,nx,ny,nz)]; // RHS value
+        for(int sx=-1; sx<=1; ++sx) {
+          for(int sy=-1; sy<=1; ++sy) {
+            for(int sz=-1; sz<=1; ++sz) {
+              sum -= -1.*xg[idx(ix+sx, iy+sy, iz+sz, nx, ny, nz, ng)];
+            }
+          }
+        }
+        sum += -1.*xg[idx(ix+0, iy+0, iz+0, nx, ny, nz, ng)]; // Remove diagnoal component entirely
 
-    for (int j = 0; j< currentNumberOfNonzeros; j++) {
-      local_int_t curCol = currentColIndices[j];
-      sum -= currentValues[j]*xv[curCol];
+        xg[idx(ix,iy,iz,nx,ny,nz)] = sum/currentDiagonal;
+      }
     }
-    sum += xv[i]*currentDiagonal; // Remove diagonal contribution from previous loop
-
-    xv[i] = sum/currentDiagonal;
   }
+
+#ifndef HPCG_NO_OPENMP
+  #pragma omp parallel for
+#endif
+  for (local_int_t ix=nx-1; ix>=0; --ix) {
+    for (local_int_t iy=ny-1; iy>=0; --iy) {
+      for (local_int_t iz=nz-1; iz>=0; --iz) {
+        double sum = rv[idx(ix,iy,iz,nx,ny,nz)]; // RHS value
+        for(int sx=1; sx>=-1; --sx) {
+          for(int sy=1; sy>=-1; --sy) {
+            for(int sz=1; sz>=-1; --sz) {
+              sum -= -1.*xg[idx(ix+sx, iy+sy, iz+sz, nx, ny, nz, ng)];
+            }
+          }
+        }
+        sum += -1.*xg[idx(ix+0, iy+0, iz+0, nx, ny, nz, ng)]; // Remove diagnoal component entirely
+
+        xv[idx(ix,iy,iz,nx,ny,nz)] = sum/currentDiagonal;
+      }
+    }
+  }
+
+  delete[] xg;
 
   return 0;
 }

--- a/src/TestCG.cpp
+++ b/src/TestCG.cpp
@@ -67,7 +67,8 @@ int TestCG(SparseMatrix & A, CGData & data, Vector & b, Vector & x, TestCGData &
   // CG should converge in about 10 iterations for this problem, regardless of problem size
   for (local_int_t i=0; i< A.localNumberOfRows; ++i) {
     global_int_t globalRowID = A.localToGlobalMap[i];
-    if (globalRowID<9) {
+    //if (globalRowID<9) {
+    if (false) {
       double scale = (globalRowID+2)*1.0e6;
       ScaleVectorValue(exaggeratedDiagA, i, scale);
       ScaleVectorValue(b, i, scale);

--- a/src/TestCG.cpp
+++ b/src/TestCG.cpp
@@ -67,8 +67,8 @@ int TestCG(SparseMatrix & A, CGData & data, Vector & b, Vector & x, TestCGData &
   // CG should converge in about 10 iterations for this problem, regardless of problem size
   for (local_int_t i=0; i< A.localNumberOfRows; ++i) {
     global_int_t globalRowID = A.localToGlobalMap[i];
-    //if (globalRowID<9) {
-    if (false) {
+    const bool is_matrix_free = true;
+    if (globalRowID<9 && !is_matrix_free) {
       double scale = (globalRowID+2)*1.0e6;
       ScaleVectorValue(exaggeratedDiagA, i, scale);
       ScaleVectorValue(b, i, scale);

--- a/src/idx.hpp
+++ b/src/idx.hpp
@@ -1,0 +1,10 @@
+#ifndef IDX_HPP
+#define IDX_HPP
+
+inline int idx(const int ix, const int iy, const int iz, const int nx, const int ny, const int nz, const int ng=0) {
+  // input index of (0, 0, 0) corresponds to first *interior* point. Ghost points are accessed with (-1, -1, -1).
+  //return (iz+ng)*(nx+2*ng)*(ny+2*ng)+(iy+ng)*(nx+2*ng)+(ix+ng);
+  return (ix+ng)*(nz+2*ng)*(ny+2*ng)+(iy+ng)*(nz+2*ng)+(iz+ng);
+}
+
+#endif  // IDX_HPP

--- a/src/idx.hpp
+++ b/src/idx.hpp
@@ -3,8 +3,7 @@
 
 inline int idx(const int ix, const int iy, const int iz, const int nx, const int ny, const int nz, const int ng=0) {
   // input index of (0, 0, 0) corresponds to first *interior* point. Ghost points are accessed with (-1, -1, -1).
-  //return (iz+ng)*(nx+2*ng)*(ny+2*ng)+(iy+ng)*(nx+2*ng)+(ix+ng);
-  return (ix+ng)*(nz+2*ng)*(ny+2*ng)+(iy+ng)*(nz+2*ng)+(iz+ng);
+  return (iz+ng)*(nx+2*ng)*(ny+2*ng) + (iy+ng)*(nx+2*ng) + (ix+ng);
 }
 
 #endif  // IDX_HPP

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -136,7 +136,7 @@ int main(int argc, char * argv[]) {
   Vector b, x, xexact;
   GenerateProblem(A, &b, &x, &xexact);
   SetupHalo(A);
-  int numberOfMgLevels = 1; // Number of levels including first
+  int numberOfMgLevels = 4; // Number of levels including first
   SparseMatrix * curLevelMatrix = &A;
   for (int level = 1; level< numberOfMgLevels; ++level) {
     GenerateCoarseProblem(*curLevelMatrix);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -136,7 +136,7 @@ int main(int argc, char * argv[]) {
   Vector b, x, xexact;
   GenerateProblem(A, &b, &x, &xexact);
   SetupHalo(A);
-  int numberOfMgLevels = 4; // Number of levels including first
+  int numberOfMgLevels = 1; // Number of levels including first
   SparseMatrix * curLevelMatrix = &A;
   for (int level = 1; level< numberOfMgLevels; ++level) {
     GenerateCoarseProblem(*curLevelMatrix);


### PR DESCRIPTION
This PR implements SPMV, SYMGS and the prolongation and restriction operators using a matrix-free method that manually applies the stencil encoded in the associated sparse matrix with extended for loops, instead of using the matrix directly. This is intended to remove the overhead of accessing the sparse matrix and the indirect memory accesses of the input vector. Things that are working:

- Valid results (as reported by HPCG) when:
  - compiling and running with `arch=Linux_Serial`
  - compiling and running with `arch=GCC_OMP` and multiple OpenMP threads
  - compiling with `arch=Linux_MPI` and running with *one MPI process*
- Toggling matrix-free and original version of each function independently
- Comparison functions to compare outputs of  the SPMV or SYMGS matrix-free calculations with the original versions.
- Indexing map that *exactly* matches the flattened memory layout of the matrix or vector inputs

Things that are still sketchy, broken or untested:
- Implementing other stencils
- MPI implementation with >1 mpi process
- Accessing the stencil properly from the input sparse matrix (or otherwise)

Previous matrix-free implementations manually handle the boundaries of the domain using generated code. This implementation uses ghost points at the edge of the boundary to incorporate known boundary values outside the domain,  allow the use of one single loop over the entire domain. This reduces the complexity and size of the code, however we perform O(x^2) more FLOPs. Since the algorithm scales with O(x^3) this should be negligible and the preliminary performance testing reported below shows the tradeoff is acceptable.

Initial performance for MPI (single process) version is:
- This PR: 8.672 GFLOP/s
- Original: 2.62676 GFLOP/s
- Generated matrix-free: 5.38418 GFLOP/s